### PR TITLE
libav memory cleanup

### DIFF
--- a/src/ffprobe-wasm-wrapper.cpp
+++ b/src/ffprobe-wasm-wrapper.cpp
@@ -131,6 +131,7 @@ FileInfoResponse get_file_info() {
       r.streams.push_back(stream);
       free(fourcc);
     }
+    avformat_close_input(&pFormatContext);
     return r;
 }
 
@@ -230,7 +231,12 @@ FramesResponse get_frames(int offset) {
         }
         frame_count++;
       }
+      av_packet_unref(pPacket);
     }
+    avformat_close_input(&pFormatContext);
+    av_packet_free(&pPacket);
+    av_frame_free(&pFrame);
+    avcodec_free_context(&pCodecContext);
     return r;
 }
 

--- a/src/ffprobe-wasm-wrapper.cpp
+++ b/src/ffprobe-wasm-wrapper.cpp
@@ -178,15 +178,14 @@ FramesResponse get_frames(int offset) {
         if (video_stream_index == -1) {
           video_stream_index = i;
           nb_frames = pFormatContext->streams[i]->nb_frames;
+
+          // Calculate the nb_frames for MKV/WebM if nb_frames is 0.
+          if (nb_frames == 0) {
+            nb_frames = (pFormatContext->duration / 1000000) * pFormatContext->streams[i]->avg_frame_rate.num;
+          }
           pCodec = pLocalCodec;
           pCodecParameters = pLocalCodecParameters;
         }
-
-        printf("Video Codec: resolution %d x %d\n",
-          pLocalCodecParameters->width, pLocalCodecParameters->height);
-      } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-        printf("Audio Codec: %d channels, sample rate %d\n",
-          pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
       }
     }
 

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ffprobe-wasm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffprobe-wasm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",


### PR DESCRIPTION
Add memory cleanup for `get_file_info` and `get_frames` to fix performance issues. Also calculate `nb_frames` for MKV files.

#3 